### PR TITLE
Added to_date_object method for use in finders

### DIFF
--- a/lib/parse_resource/base.rb
+++ b/lib/parse_resource/base.rb
@@ -491,7 +491,7 @@ module ParseResource
 
     def set_attribute(k, v)
       if v.is_a?(Date) || v.is_a?(Time) || v.is_a?(DateTime)
-        v = self.to_date_object(v)
+        v = {"__type" => "Date", "iso" => v.iso8601}
       elsif v.respond_to?(:to_pointer)
         v = v.to_pointer 
       end


### PR DESCRIPTION
Previously the programmer had to manually pass a hash/object to the where method to find a row by a date: `Post.where("date" => ($lt => {"__type" => "Date", "iso" => date.iso8601}))`

With this method all you have to do is pass the method the date: `Post.where("date" => ($lt => Post.to_date_object(date)))`

(my examples may not be formatted perfectly, just trying to get the idea across)
