### PR TITLE
fix error message

### DIFF
--- a/lib/parse_resource/parse_error.rb
+++ b/lib/parse_resource/parse_error.rb
@@ -28,8 +28,7 @@ class ParseError
   end
   
   def to_array
-    @error[1] = @error[1] + " " + @msg
-    @error
+    return [@error, @msg]
   end
   
 end


### PR DESCRIPTION
in extended Parse::Resource models, error message is not working well.
(in my machine, always :B => 'a'  is message)

i fixed it , and looks like it is bug.
