### PR TITLE
Add kaminari for pagination

### DIFF
--- a/lib/kaminari_extension.rb
+++ b/lib/kaminari_extension.rb
@@ -1,0 +1,38 @@
+module KaminariExtension
+  module ParseBaseExt
+    extend ActiveSupport::Concern
+    include Kaminari::ConfigurationMethods
+
+    module ClassMethods
+      def page(num)
+        Query.new(self).limit(default_per_page).skip(default_per_page * ([num.to_i, 1].max - 1))
+      end
+    end
+  end
+
+  module QueryExt
+    extend ActiveSupport::Concern
+    include Kaminari::PageScopeMethods
+
+    included do
+      alias :offset :skip
+    end
+
+    def limit_value
+      criteria[:limit]
+    end
+
+    def offset_value
+      criteria[:skip]
+    end
+
+    def total_count
+      count
+    end
+  end
+end
+
+if defined?(Kaminari)
+  ParseResource::Base.send :include, KaminariExtension::ParseBaseExt
+  Query.send               :include, KaminariExtension::QueryExt
+end

--- a/lib/parse_resource.rb
+++ b/lib/parse_resource.rb
@@ -5,6 +5,7 @@ require 'parse_resource/query'
 require 'parse_resource/parse_user'
 require 'parse_resource/parse_user_validator'
 require 'parse_resource/parse_error'
+require 'kaminari_extension'
 
 
 module ParseResource


### PR DESCRIPTION
I wrote small extension for kaminari. It's optional. When you have kaminari on board you can easily paginate you results:

```
Model.page(1).per(200).all 
```

and use all of the kaminari goodies. (https://github.com/amatsuda/kaminari)
