### PR TITLE
Add related_to query constraint.

### DIFF
--- a/README.md
+++ b/README.md
@@ -303,6 +303,10 @@ posts.each do |post|
 	# because you used Post#include_object, calling post.title won't execute a new query
 	# this is similar to ActiveRecord's eager loading
 end
+
+# fetch users through a relation on posts named commenters
+post = Post.first
+users = User.related_to(post, commenters)
 ```
 
 File Upload

--- a/lib/parse_resource/query.rb
+++ b/lib/parse_resource/query.rb
@@ -84,6 +84,12 @@ class Query
     self
   end
 
+  def related_to(obj, key)
+    query = { "$relatedTo" => { "object" => obj.to_pointer, "key" => key } }
+    criteria[:conditions].merge!(query)
+    self
+  end
+
   def execute
     params = {}
     params.merge!({:where => criteria[:conditions].to_json}) if criteria[:conditions]

--- a/lib/parse_resource/query_methods.rb
+++ b/lib/parse_resource/query_methods.rb
@@ -55,6 +55,10 @@ module ParseResource
       def within_box(near, geo_point_south, geo_point_north)
         Query.new(self).within_box(near, geo_point_south, geo_point_north)
       end
+
+      def related_to(obj, key)
+        Query.new(self).related_to(obj, key)
+      end
 		end
 
 		def self.included(base)


### PR DESCRIPTION
This adds a related_to method to Query which can be used to query objects that are in a relation in another object.

I tested this within a project I'm working on that has object with relations.  I would have liked to add tests to parse_resource how to do so given that I am not sure how to create the relations as part of the test.  If there's a way to do that I'd be happy to try to add the appropriate tests.
