### PR TITLE
Properly handle duplicate email (error code 203)

### DIFF
--- a/lib/parse_resource/parse_error.rb
+++ b/lib/parse_resource/parse_error.rb
@@ -17,6 +17,8 @@ class ParseError
       @error = "Unknown device type."
     when "202"
       @error = "Username already taken."
+    when "203"
+      @error = "Email already taken."
     when "400"
       @error = "Bad Request: The request cannot be fulfilled due to bad syntax."
     when "401"


### PR DESCRIPTION
Handles response code 203 for duplicate email instead of raising a RuntimeException
