### PR TITLE
Fix TypeError in rescue clouse

### DIFF
--- a/lib/parse_resource/base.rb
+++ b/lib/parse_resource/base.rb
@@ -398,7 +398,8 @@ module ParseResource
       else
         false
       end
-      rescue false
+    rescue
+      false
     end
 
     def create


### PR DESCRIPTION
`ParseResouce::Base#save` currently raises `TypeError: class or module required for rescue clause` when `create` or `update` methods raises an error. This is due to `rescue false` only work in single line form. Fixing this by using rescue in multi line form...

(I'm assuming the original intention was `ParseResouce::Base#save` always return false when it fails for any exception)
