### PR TITLE
Use UTC timestamp as per Parse documentation

### DIFF
--- a/lib/parse_resource/base.rb
+++ b/lib/parse_resource/base.rb
@@ -98,7 +98,7 @@ module ParseResource
 
     def self.to_date_object(date)
       date = date.to_time if date.respond_to?(:to_time)
-      {"__type" => "Date", "iso" => date.iso8601} if date && (date.is_a?(Date) || date.is_a?(DateTime) || date.is_a?(Time))
+      {"__type" => "Date", "iso" => date.getutc.iso8601} if date && (date.is_a?(Date) || date.is_a?(DateTime) || date.is_a?(Time))
     end
 
     # Creates setter methods for model fields

--- a/test/test_parse_resource.rb
+++ b/test/test_parse_resource.rb
@@ -343,10 +343,10 @@ class TestParseResource < Test::Unit::TestCase
   def test_to_date_object
     VCR.use_cassette('test_to_date_object', :record => :new_episodes) do
       date = DateTime.strptime("Thu, 11 Oct 2012 10:20:40 -0700", '%a, %d %b %Y %H:%M:%S %z')
-      array = {"__type"=>"Date", "iso"=>"2012-10-11T10:20:40-07:00"}
+      array = {"__type"=>"Date", "iso"=>"2012-10-11T17:20:40Z"}
       date_pointer = Post.to_date_object(date)
       assert_equal array["__type"], date_pointer["__type"]
-      assert date_pointer["iso"].start_with?("2012-10-11") # TODO: figure out a way around the time zone issue
+      assert_equal array["iso"], date_pointer["iso"]
     end
   end
   


### PR DESCRIPTION
As per Parse documentation, `iso` field of `Date` type is supposed to be in `UTC` timestamp.   

https://parse.com/docs/rest#objects-types

This also fixes timezone issue of `test_to_date_object` ( https://github.com/adelevie/parse_resource/issues/82 )
