### PR TITLE
Fix to_time_in_current_zone deprecation warning

### DIFF
--- a/lib/parse_resource/base.rb
+++ b/lib/parse_resource/base.rb
@@ -530,7 +530,7 @@ module ParseResource
         when "Object"
           result = klass_name.to_s.constantize.new(attrs[k], false)
         when "Date"
-          result = DateTime.parse(attrs[k]["iso"]).to_time_in_current_zone
+          result = DateTime.parse(attrs[k]["iso"]).in_time_zone
         when "File"
           result = attrs[k]["url"]
         when "GeoPoint"


### PR DESCRIPTION
This pull request fixes the `to_time_in_current_zone` deprecation warning by
replacing the old method with the new `in_time_zone` method.
