### PR TITLE
Add validation callbacks to base module

### DIFF
--- a/lib/parse_resource/base.rb
+++ b/lib/parse_resource/base.rb
@@ -22,6 +22,7 @@ module ParseResource
     #  end
 
     include ActiveModel::Validations
+    include ActiveModel::Validations::Callbacks
     include ActiveModel::Conversion
     include ActiveModel::AttributeMethods
     extend ActiveModel::Naming


### PR DESCRIPTION
This pull request adds validation callbacks to the `ParseResource::Base`
module so that callbacks like `before_validation` are available.
