### PR TITLE
fix documentation for file upload method

### DIFF
--- a/README.md
+++ b/README.md
@@ -321,7 +321,7 @@ File Upload
 ```ruby
   @post = Post.first()
   result = Post.upload(uploaded_file.tempfile, uploaded_file.original_filename, content_type: uploaded_file.content_type)
-  @post.thumbnail = {"name" => result["name"], "__type" => "File"}
+  @post.thumbnail = {"name" => result["name"], "__type" => "File", "url" => result["url"]}
 ```
 
 Custom Getters and Setters


### PR DESCRIPTION
The documentation for file uploads was missing a parameter. I needed this to save uploads successfully.
