### PR TITLE
Fixing the reference to ParseRole vs Role

### DIFF
--- a/lib/parse_resource/base.rb
+++ b/lib/parse_resource/base.rb
@@ -189,7 +189,7 @@ module ParseResource
         "users"
       elsif self.model_name.to_s == "Installation"
         "installations"
-      elsif self.model_name.to_s == "Role"
+      elsif self.model_name.to_s == "ParseRole"
         "roles"
       else
         "classes/#{self.model_name.to_s}"


### PR DESCRIPTION
The implemented ParseRole class to_s method returns ParseRole, naturally - needed to make the model_name_uri match this instead of "Role".
