### PR TITLE
Fixing Role inheritance check

### DIFF
--- a/lib/parse_resource/base.rb
+++ b/lib/parse_resource/base.rb
@@ -189,7 +189,7 @@ module ParseResource
         "users"
       elsif self.model_name.to_s == "Installation"
         "installations"
-      elsif self.model_name.to_s == "Role"
+      elsif self.model_name.to_s.constantize <= ParseRole
         "roles"
       else
         "classes/#{self.model_name.to_s}"


### PR DESCRIPTION
Previously required Role<ParseRole; now, the inheriting role can be named anything.
