### PR TITLE
Resource .get method takes params directly

### DIFF
--- a/lib/parse_resource/query.rb
+++ b/lib/parse_resource/query.rb
@@ -122,7 +122,7 @@ class Query
 
     return chunk_results(params) if criteria[:chunk]
 
-    resp = @klass.resource.get(:params => params)
+    resp = @klass.resource.get(params)
     
     if criteria[:count] == 1
       results = JSON.parse(resp)['count']


### PR DESCRIPTION
Having the :params => params was causing a 400 error, as it essentially was causing the .get to turn the params into something irrelevant to the REST API.
